### PR TITLE
update badges

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,12 +25,10 @@ jobs:
       - name: Fetch latest tag
         id: get-latest-chart-tag
         run: |
-          latest_tag="$(git tag --list --sort='-*authordate' | head -n 1)"
-          echo "$latest_tag"
+          latest_tag="$(git tag --list --sort='-authordate' | head -n 1)"
           if [[ "$latest_tag" =~ "chart-".* ]]; then
             echo "latest-chart-tag=$latest_tag" >> "$GITHUB_OUTPUT"
           fi
-          echo "$GITHUB_OUTPUT"
       - name: Setup go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,9 +26,11 @@ jobs:
         id: get-latest-chart-tag
         run: |
           latest_tag="$(git tag --list --sort='-*authordate' | head -n 1)"
+          echo "$latest_tag"
           if [[ "$latest_tag" =~ "chart-".* ]]; then
             echo "latest-chart-tag=$latest_tag" >> "$GITHUB_OUTPUT"
           fi
+          echo "$GITHUB_OUTPUT"
       - name: Setup go
         uses: actions/setup-go@v5
         with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![GoTemplate](https://img.shields.io/badge/go/template-black?logo=go)](https://github.com/golang-standards/project-layout)
 [![Go](https://img.shields.io/badge/go-1.24.0-blue?logo=go)](https://golang.org/)
 [![Cert Manager](https://img.shields.io/badge/cert--manager-1.17.1-blue?logo=cert-manager)](https://cert-manager.io/)
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/packages/helm/cert-manager-webhook-ionos-cloud/cert-manager-webhook-ionos-cloud)](https://artifacthub.io/packages/search?repo=cert-manager-webhook-ionos-cloud)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cert-manager-webhook-ionos-cloud)](https://artifacthub.io/packages/search?repo=cert-manager-webhook-ionos-cloud)
 
 ![Alt text](.github/IONOS.CLOUD.BLU.svg?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 [![GoTemplate](https://img.shields.io/badge/go/template-black?logo=go)](https://github.com/golang-standards/project-layout)
-[![Go](https://img.shields.io/badge/go-1.22.0-blue?logo=go)](https://golang.org/)
-[![Helm](https://img.shields.io/badge/helm-3.12.3-blue?logo=helm)](https://helm.sh/)
-[![Kubernetes](https://img.shields.io/badge/kubernetes-1.30.2-blue?logo=kubernetes)](https://kubernetes.io/)
-[![Cert Manager](https://img.shields.io/badge/cert--manager-1.15.2-blue?logo=cert-manager)](https://cert-manager.io/)
+[![Go](https://img.shields.io/badge/go-1.24.0-blue?logo=go)](https://golang.org/)
+[![Cert Manager](https://img.shields.io/badge/cert--manager-1.17.1-blue?logo=cert-manager)](https://cert-manager.io/)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/packages/helm/cert-manager-webhook-ionos-cloud/cert-manager-webhook-ionos-cloud)](https://artifacthub.io/packages/search?repo=cert-manager-webhook-ionos-cloud)
 
 ![Alt text](.github/IONOS.CLOUD.BLU.svg?raw=true)
 


### PR DESCRIPTION
* added a new badge for artifacthub.io
* removed the helm and kubernetes badges to avoid confusing users. It may be understood from the badges that the webhook works only with certain Kubernetes or Helm version. However, the app supports all the supported Kubernetes and Helm versions. Unless the meaning of those badges is the minimum supported version:)
* updated the cert-manager and the go badges

![github com_ionos-cloud_cert-manager-webhook-ionos-cloud_tree_badges_improvement](https://github.com/user-attachments/assets/91e930bd-a606-4ae7-a88a-83197b373169)
