### PR TITLE
feat(chart): add support for custom container environment variables

### DIFF
--- a/chart/cert-manager-webhook-ionos-cloud/Chart.yaml
+++ b/chart/cert-manager-webhook-ionos-cloud/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.3.0"

--- a/chart/cert-manager-webhook-ionos-cloud/Chart.yaml
+++ b/chart/cert-manager-webhook-ionos-cloud/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.2.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.0"
+appVersion: "0.1.0"

--- a/chart/cert-manager-webhook-ionos-cloud/README.md
+++ b/chart/cert-manager-webhook-ionos-cloud/README.md
@@ -8,7 +8,6 @@ This webhook allows you to utilize IONOS Cloud as a DNS provider for performing 
 
 Cert-manager is a powerful Kubernetes add-on that automates the management and issuance of TLS certificates from various issuing sources. The IONOS Cloud Webhook extends cert-manager's capabilities to manage DNS challenges using IONOS Cloud's DNS services.
 
-
 ## Usage
    
 1. ***Install the webhook server***
@@ -19,6 +18,17 @@ Cert-manager is a powerful Kubernetes add-on that automates the management and i
     --install cert-manager-webhook-ionos-cloud/cert-manager-webhook-ionos-cloud
     ```
 
+    Note that you can set custom environment variables if needed. For example, proxy configuration for restricted environments:
+    ```yaml
+    # values.yaml
+    env:
+      - name: HTTP_PROXY
+        value: "http://proxy.company.com:8080"
+      - name: HTTPS_PROXY
+        value: "http://proxy.company.com:8080"
+      - name: NO_PROXY
+        value: "localhost,127.0.0.1,.local,.cluster.local"
+    ```
 
 2. ***Initiation of IONOS Cloud Authentication Token Secret:***
     See [IONOS Cloud Token management](https://docs.ionos.com/cloud/set-up-ionos-cloud/management/token-management) for how to get a token.

--- a/chart/cert-manager-webhook-ionos-cloud/templates/deployment.yaml
+++ b/chart/cert-manager-webhook-ionos-cloud/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: https
               containerPort: 8443

--- a/chart/cert-manager-webhook-ionos-cloud/templates/deployment.yaml
+++ b/chart/cert-manager-webhook-ionos-cloud/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.namespace
             {{- with .Values.env }}
-            {{- toYaml . | nindent 12 }}
+            {{ toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: https

--- a/chart/cert-manager-webhook-ionos-cloud/values.yaml
+++ b/chart/cert-manager-webhook-ionos-cloud/values.yaml
@@ -14,7 +14,24 @@ certManager:
 
 replicaCount: 1
 
-# Additional environment variables
+## Additional container environment variables
+##
+## You specify this manually like you would a raw deployment manifest.
+## This means you can bind in environment variables from secrets.
+##
+## e.g. static environment variables:
+##  - name: HTTP_PROXY
+##    value: "http://proxy.example.com:8080"
+##  - name: HTTPS_PROXY
+##    value: "http://proxy.example.com:8080"
+##  - name: NO_PROXY
+##    value: "localhost,127.0.0.1,.svc"
+## e.g. secret environment variable:
+## - name: USERNAME
+##   valueFrom:
+##     secretKeyRef:
+##       name: mysecret
+##       key: username
 env: []
 
 image:

--- a/chart/cert-manager-webhook-ionos-cloud/values.yaml
+++ b/chart/cert-manager-webhook-ionos-cloud/values.yaml
@@ -12,6 +12,11 @@ certManager:
   serviceAccountName: cert-manager
   namespace: cert-manager
 
+replicaCount: 1
+
+# Additional environment variables
+env: []
+
 image:
   tag: latest
   repository: ghcr.io/ionos-cloud/cert-manager-webhook-ionos-cloud


### PR DESCRIPTION
Fixes https://github.com/ionos-cloud/cert-manager-webhook-ionos-cloud/issues/78

This pull request updates the Helm chart for `cert-manager-webhook-ionos-cloud` to add support for custom container environment variables, set a default replica count, and bump both the chart and application versions. These changes improve the chart's flexibility and make it easier to configure deployments for different environments.

**Chart enhancements:**

* Added a new `env` field in `values.yaml` to allow users to specify additional environment variables for the container, including support for static values and secret references.
* Updated the deployment template (`deployment.yaml`) to inject any environment variables defined in the `env` field.
* Fixes missing a `replicaCount` field in `values.yaml` to allow configuration of the number of deployment replicas.

**Version updates:**

* Bumped the chart version to `0.2.0`.