### PR TITLE
feat(ci): verify chart version bump on changes

### DIFF
--- a/.github/workflows/on_tag.yml
+++ b/.github/workflows/on_tag.yml
@@ -18,13 +18,6 @@ jobs:
           fetch-depth: 0
       - name: Git Fetch
         run: git fetch --force --tags
-      - name: Fetch latest tag
-        id: get-latest-chart-tag
-        run: |
-          latest_tag=$(git tag --list --sort='-*authordate' | head -n 1)
-          if [[ "$latest_tag" =~ "chart-".* ]]; then
-            echo "latest-chart-tag=$latest_tag" >> "$GITHUB_OUTPUT"
-          fi
       - name: Setup go
         uses: actions/setup-go@v5
         with:
@@ -53,4 +46,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_KEY_PASSWORD}}
-          IGNORE_TAG: ${{ steps.get-latest-chart-tag.outputs.latest-chart-tag }}

--- a/.github/workflows/on_tag.yml
+++ b/.github/workflows/on_tag.yml
@@ -46,3 +46,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PRIVATE_KEY: ${{secrets.COSIGN_PRIVATE_KEY}}
           COSIGN_PASSWORD: ${{secrets.COSIGN_KEY_PASSWORD}}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,54 @@ permissions:
   checks: write
   
 jobs:
+  validate-chart-version:
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Check if chart files changed
+        id: check-chart-changes
+        run: |
+          git fetch origin main:main
+          if git diff --name-only origin/main...HEAD | grep -q '^chart/'; then
+            echo "chart-changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "chart-changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Get current chart version
+        id: current-version
+        if: steps.check-chart-changes.outputs.chart-changed == 'true'
+        run: |
+          current_version=$(grep '^version:' chart/cert-manager-webhook-ionos-cloud/Chart.yaml | awk '{print $2}')
+          echo "current-version=$current_version" >> "$GITHUB_OUTPUT"
+      - name: Get main branch chart version
+        id: main-version
+        if: steps.check-chart-changes.outputs.chart-changed == 'true'
+        run: |
+          git checkout main
+          main_version=$(grep '^version:' chart/cert-manager-webhook-ionos-cloud/Chart.yaml | awk '{print $2}')
+          echo "main-version=$main_version" >> "$GITHUB_OUTPUT"
+          git checkout -
+      - name: Validate version bump
+        if: steps.check-chart-changes.outputs.chart-changed == 'true'
+        run: |
+          current="${{ steps.current-version.outputs.current-version }}"
+          main="${{ steps.main-version.outputs.main-version }}"
+          
+          echo "Current chart version: $current"
+          echo "Main branch chart version: $main"
+          
+          if [ "$current" = "$main" ]; then
+            echo "❌ Chart files were modified but chart version was not bumped!"
+            echo "Please increment the version in chart/cert-manager-webhook-ionos-cloud/Chart.yaml"
+            echo "Current version: $current"
+            exit 1
+          else
+            echo "✅ Chart version was properly bumped from $main to $current"
+          fi
   snapshot-release:
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -70,13 +70,12 @@ jobs:
           fetch-depth: 0
       - name: Git Fetch
         run: git fetch --force --tags
-      - name: Fetch latest tag
-        id: get-latest-chart-tag
+      - name: Get latest non-chart tag
+        id: get-latest-release-tag
         run: |
-          latest_tag="$(git tag --list --sort='-authordate' | head -n 1)"
-          if [[ "$latest_tag" =~ "chart-".* ]]; then
-            echo "latest-chart-tag=$latest_tag" >> "$GITHUB_OUTPUT"
-          fi
+          latest_release_tag="$(git tag --list --sort='-version:refname' | grep -v '^chart-' | head -n 1)"
+          echo "latest-release-tag=$latest_release_tag" >> "$GITHUB_OUTPUT"
+          echo "Using release tag: $latest_release_tag"
       - name: Setup go
         uses: actions/setup-go@v5
         with:
@@ -115,4 +114,4 @@ jobs:
           version: v2.9.0
           args: release --snapshot --clean --skip=publish
         env:
-          IGNORE_TAG: ${{ steps.get-latest-chart-tag.outputs.latest-chart-tag }}
+          GORELEASER_CURRENT_TAG: ${{ steps.get-latest-release-tag.outputs.latest-release-tag }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,6 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
 
-git:
-  ignore_tags:
-    - "{{.Env.IGNORE_TAG}}"
-
 project_name: cert-manager-webhook-ionos-cloud
 snapshot:
   version_template: '{{ .Tag }}-SNAPSHOT'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows and the GoReleaser configuration to improve release and version management, especially around Helm chart changes. The main improvements include enforcing chart version bumps when chart files change, refining how release tags are handled, and simplifying the GoReleaser configuration.

**Workflow and Release Process Improvements:**

* Added a `validate-chart-version` job to `.github/workflows/pull_request.yml` that checks if chart files were modified in a pull request and enforces that the chart version is bumped accordingly. This prevents accidental chart changes without version updates.

* Updated the process for determining the latest release tag in both `.github/workflows/pull_request.yml` and `.github/workflows/on_tag.yml`. The workflow now fetches the latest non-chart tag for release purposes, ensuring that chart-specific tags do not interfere with the main release process. [[1]](diffhunk://#diff-a0fe23534b616d51ce686d2a1bcd1a78bc75074aef1a2f6ee96c9469991e1a4cL25-R78) [[2]](diffhunk://#diff-9dbf7e364324dc6e32636139db31715706eb41699886e774c323e6edf441b19fL21-L27)

* Changed environment variables used in release steps: replaced `IGNORE_TAG` with `GORELEASER_CURRENT_TAG` to align with the new tag selection logic and simplify configuration. [[1]](diffhunk://#diff-a0fe23534b616d51ce686d2a1bcd1a78bc75074aef1a2f6ee96c9469991e1a4cL70-R117) [[2]](diffhunk://#diff-9dbf7e364324dc6e32636139db31715706eb41699886e774c323e6edf441b19fL56)

**GoReleaser Configuration Cleanup:**

* Removed the `git.ignore_tags` section from `.goreleaser.yml` since tag ignoring is now handled in the workflow, streamlining the configuration.