### PR TITLE
fix(ci): use correct tag for chart url

### DIFF
--- a/.github/workflows/deploy_chart.yaml
+++ b/.github/workflows/deploy_chart.yaml
@@ -43,16 +43,9 @@ jobs:
               run: |
                 git checkout helm-repo
                 helm repo index . --merge index.yaml \
-                --url https://github.com/ionos-cloud/cert-manager-webhook-ionos-cloud/releases/download/chart-${{ steps.get-chart-version.outputs.chart-version }}/
+                --url https://github.com/ionos-cloud/cert-manager-webhook-ionos-cloud/releases/download/${{ steps.get-chart-version.outputs.chart-version }}-chart+${{ steps.get-latest-tag.outputs.latest-tag }}/
                 git config user.email "no-reply@ionos-cloud.com";
                 git config user.name "IONOS-CloudBot";
                 git add index.yaml
                 git commit -m "chore(chart): update helm repository index"
                 git push origin helm-repo
-    
-
-            
-
-            
-
-            


### PR DESCRIPTION
We missed this in https://github.com/ionos-cloud/cert-manager-webhook-ionos-cloud/pull/81 